### PR TITLE
[toml] Limit multiline{Literal/String} to a single end quotation mark

### DIFF
--- a/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/String.scala
+++ b/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/String.scala
@@ -24,7 +24,7 @@ val multilineLiteral: Parser[String] =
   (
     newline.?.with1 *> (
       (Parser.not(tripleSingleQuote).with1 *> Parser.anyChar).rep.string |
-        (Parser.char('\'').string <* Parser.peek(tripleSingleQuote)).backtrack // Note: this is from the spec, sorry :C
+        (Parser.char('\'').string <* Parser.peek(tripleSingleQuote <* Parser.not(singleQuote))).backtrack
     ).withContext("multilineLiteral.line")
       .rep
       .map(_.toList.mkString(""))
@@ -61,7 +61,7 @@ val multilineString: Parser[String] =
     newline.?.with1 *> (
       (Parser.not(tripleDoubleQuote | backslash).with1 *> Parser.anyChar).rep.string |
         escaped.backtrack | escapedUnicode4.backtrack | escapedUnicode8.backtrack | escapedNewline.backtrack |
-        (Parser.char('\"').string <* Parser.peek(tripleDoubleQuote)).backtrack // Note: this is from the spec, sorry :C
+        (Parser.char('\"').string <* Parser.peek(tripleDoubleQuote <* Parser.not(doubleQuote))).backtrack
     ).withContext("multilineString.line").rep.map(_.toList.mkString(""))
   ).surroundedBy(tripleDoubleQuote).withContext("multilineString")
 

--- a/code/lib/toml/parse/src/test/scala/dev/librecybernetics/parser/toml/base/StringSpec.scala
+++ b/code/lib/toml/parse/src/test/scala/dev/librecybernetics/parser/toml/base/StringSpec.scala
@@ -1,9 +1,12 @@
 package dev.librecybernetics.parser.toml.base
 
 import cats.implicits.*
-import dev.librecybernetics.parser.*
+import cats.parse.Parser
+
 import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.wordspec.AnyWordSpec
+
+import dev.librecybernetics.parser.*
 
 class StringSpec extends AnyWordSpec {
   "String" when {
@@ -40,7 +43,9 @@ class StringSpec extends AnyWordSpec {
         "\"Here are fifteen apostrophes: '''''''''''''''\""                                                    ->
           "Here are fifteen apostrophes: '''''''''''''''",
         "''''That,' she said, 'is still pointless.''''"                                                        ->
-          "'That,' she said, 'is still pointless.'"
+          "'That,' she said, 'is still pointless.'",
+        "\"\"\"\"This,\" she said, \"is just a pointless statement.\"\"\"\"" ->
+          "\"This,\" she said, \"is just a pointless statement.\""
       ) foreach { (si, sr) =>
         si in genericSuccess(string)(si, sr)
       }
@@ -73,9 +78,13 @@ class StringSpec extends AnyWordSpec {
             "context: multilineString, context: tripleDoubleQuote, must match string: \"\"\"\"\"",
             "context: multilineLiteral, context: tripleSingleQuote, must match string: \"'''\"",
             "must be char: '\"'"
-          )
+          ),
+        "\"\"\"6 quotes: \"\"\"\"\"\"" ->
+          Seq("must end the string"),
+        "'''15 apostrophes: ''''''''''''''''''" ->
+          Seq("must end the string")
       ) foreach { (s, m) =>
-        s in genericFailure(string)(s, m*)
+        s in genericFailure(string <* Parser.end)(s, m*)
       }
     }
   }


### PR DESCRIPTION
```
toml-test [/home/fabian/Development/LibreCybernetics/Monorepo/code/lib/toml/tomltest/.native/target/scala-3.2.2/toml-tomltest-out]: using embedded tests: 299 passed, 115 failed
```