### PR TITLE
[toml] Better String checks and refactor

### DIFF
--- a/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/Comment.scala
+++ b/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/Comment.scala
@@ -7,15 +7,12 @@ import cats.parse.{Parser, Parser0}
 import dev.librecybernetics.parser.*
 import dev.librecybernetics.types.TOML
 
-// Note: u000A Line Feed (LF) is \n as such it isn't included
-private val disallowedChars: Set[Char] =
-  ('\u0000' to '\u0008').toSet ++ ('\u000B' to '\u001F').toSet + '\u007F'
-
 private val commentStart: Parser[Unit] =
   (hash ~ space.?).void
 
 private val commentContent: Parser[String] =
-  anyUntilNewline filter (c => !(c exists (disallowedChars contains)))
+  anyUntilNewline
+    .checkDisallowedChars
 
 private val singleComment: Parser[String] =
   (commentStart *> commentContent <* Parser.peek(newlineOrEnd)).backtrack

--- a/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/DisallowedChars.scala
+++ b/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/DisallowedChars.scala
@@ -1,0 +1,20 @@
+package dev.librecybernetics.parser.toml.base
+
+import cats.parse.Parser
+
+// Note: u000A Line Feed (LF) is \n as such it isn't included
+private val disallowedChars: Set[Char] =
+  ('\u0000' to '\u0008').toSet ++ ('\u000B' to '\u001F').toSet + '\u007F'
+
+extension (p: Parser[String])
+  def checkDisallowedChars: Parser[String] =
+    p.flatMap { s =>
+      s find disallowedChars.contains match
+        case Some(disallowed) =>
+          val char: String = disallowed.toInt.toHexString
+          Parser.failWith(
+            s"Disallowed control character detected: $char"
+          )
+        case None             =>
+          Parser.pure(s)
+    }

--- a/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/LiteralString.scala
+++ b/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/LiteralString.scala
@@ -1,0 +1,23 @@
+package dev.librecybernetics.parser.toml.base
+
+import cats.parse.Parser
+
+import dev.librecybernetics.parser.*
+
+private val singleQuote = Parser.char('\'')
+private val tripleSingleQuote = Parser.string("'''").withContext("tripleSingleQuote")
+
+val simpleLiteral: Parser[String] =
+  Parser
+    .charsWhile(c => !(Set('\'', '\n') contains c))
+    .surroundedBy(singleQuote)
+
+val multilineLiteral: Parser[String] =
+  (
+    newline.?.with1 *> (
+      (Parser.not(tripleSingleQuote).with1 *> Parser.anyChar).rep.string |
+        (Parser.char('\'').string <* Parser.peek(tripleSingleQuote <* Parser.not(singleQuote))).backtrack
+      ).withContext("multilineLiteral.line")
+      .rep
+      .map(_.toList.mkString(""))
+    ).surroundedBy(tripleSingleQuote).withContext("multilineLiteral")

--- a/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/SpecialEscapes.scala
+++ b/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/SpecialEscapes.scala
@@ -1,0 +1,23 @@
+package dev.librecybernetics.parser.toml.base
+
+import cats.parse.Parser
+
+import dev.librecybernetics.parser.*
+
+private val escaped: Parser[Char] =
+  Map(
+    "\\b"  -> '\b',
+    "\\t"  -> '\t',
+    "\\n"  -> '\n',
+    "\\f"  -> '\f',
+    "\\r"  -> '\r',
+    "\\\"" -> '"',
+    "\\\\" -> '\\'
+  ).map { (s, c) =>
+    Parser.string(s).map(_ => c)
+  }.reduceOption(_.backtrack | _.backtrack)
+    .getOrElse(Parser.fail)
+
+private val escapedNewline: Parser[String] =
+  (Parser.string("\\\n").map(_ => "") <* emptyLine.backtrack.rep0 <* spaces)
+    .withContext("escapedNewline")

--- a/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/String.scala
+++ b/code/lib/toml/parse/src/main/scala/dev/librecybernetics/parser/toml/base/String.scala
@@ -1,52 +1,12 @@
 package dev.librecybernetics.parser.toml.base
 
-import java.lang.Integer
-import scala.language.postfixOps
-
 import cats.implicits.*
 import cats.parse.Parser
-import cats.parse.Accumulator0.charStringAccumulator0
 
 import dev.librecybernetics.parser.*
 
-private val singleQuote = Parser.char('\'')
 private val doubleQuote = Parser.char('"')
-
-private val tripleSingleQuote = Parser.string("'''").withContext("tripleSingleQuote")
 private val tripleDoubleQuote = Parser.string("\"\"\"").withContext("tripleDoubleQuote")
-
-val simpleLiteral: Parser[String] =
-  Parser
-    .charsWhile(c => !(Set('\'', '\n') contains c))
-    .surroundedBy(singleQuote)
-
-val multilineLiteral: Parser[String] =
-  (
-    newline.?.with1 *> (
-      (Parser.not(tripleSingleQuote).with1 *> Parser.anyChar).rep.string |
-        (Parser.char('\'').string <* Parser.peek(tripleSingleQuote <* Parser.not(singleQuote))).backtrack
-    ).withContext("multilineLiteral.line")
-      .rep
-      .map(_.toList.mkString(""))
-  ).surroundedBy(tripleSingleQuote).withContext("multilineLiteral")
-
-private val escaped: Parser[Char] =
-  Map(
-    "\\b"  -> '\b',
-    "\\t"  -> '\t',
-    "\\n"  -> '\n',
-    "\\f"  -> '\f',
-    "\\r"  -> '\r',
-    "\\\"" -> '"',
-    "\\\\" -> '\\'
-  ).map { (s, c) =>
-    Parser.string(s).map(_ => c)
-  }.reduceOption(_.backtrack | _.backtrack)
-    .getOrElse(Parser.fail)
-
-private val escapedNewline: Parser[String] =
-  (Parser.string("\\\n").map(_ => "") <* emptyLine.backtrack.rep0 <* spaces)
-    .withContext("escapedNewline")
 
 val simpleString: Parser[String] =
   (
@@ -62,10 +22,17 @@ val multilineString: Parser[String] =
       (Parser.not(tripleDoubleQuote | backslash).with1 *> Parser.anyChar).rep.string |
         escaped.backtrack | escapedUnicode4.backtrack | escapedUnicode8.backtrack | escapedNewline.backtrack |
         (Parser.char('\"').string <* Parser.peek(tripleDoubleQuote <* Parser.not(doubleQuote))).backtrack
-    ).withContext("multilineString.line").rep.map(_.toList.mkString(""))
-  ).surroundedBy(tripleDoubleQuote).withContext("multilineString")
+    )
+      .withContext("multilineString.line")
+      .rep
+      .map(_.toList.mkString(""))
+  )
+    .surroundedBy(tripleDoubleQuote)
+    .withContext("multilineString")
 
 val string: Parser[String] =
   // Note: "" is a valid simple string, check triple quote first
-  multilineLiteral.backtrack | simpleLiteral.backtrack |
-    multilineString.backtrack | simpleString.backtrack
+  (
+    multilineLiteral.backtrack | simpleLiteral.backtrack |
+      multilineString.backtrack | simpleString.backtrack
+  ).checkDisallowedChars


### PR DESCRIPTION
```
using embedded tests: 335 passed, 79 failed

________________________________________________________
Executed in   37.77 secs    fish           external
   usr time   35.39 secs  519.00 micros   35.38 secs
   sys time   11.71 secs    0.00 micros   11.71 secs
```