### PR TITLE
flake: add nodejs and clang

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1682018913,
-        "narHash": "sha256-Eo2ZkWB8+qy8fnmxtJUNJl6HHYYAgXDR29+OwDIzm1Q=",
+        "lastModified": 1682566018,
+        "narHash": "sha256-HPzPRFiy2o/7k7mtnwfM1E6NVZHiFbPdmYCMoIpkHO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7048a48bc79b4361f77740420000d2b5454b0df7",
+        "rev": "8e3b64db39f2aaa14b35ee5376bd6a2e707cadc2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
           
           packages = with pkgs;[
             jdk
+            llvmPackages_latest.clang
+            nodejs
             (sbt.override {
               jre = jdk;
             })


### PR DESCRIPTION
flake.lock: 2023-04-22 → 2023-04-27

audit: 2.8.5 → 3.1, +67.5 KiB
libpcap: 1.10.3 → 1.10.4
libxml2: 2.10.3 → 2.10.4
python3: 3.10.10 → 3.10.11, -22.8 KiB
zstd: 1.5.4 → 1.5.5, +39.6 KiB